### PR TITLE
implemented gamepad event filtering

### DIFF
--- a/Game/src/input/GamepadState.lua
+++ b/Game/src/input/GamepadState.lua
@@ -1,0 +1,29 @@
+
+GamepadState = Object:extend()
+
+function GamepadState:new()
+  self.keys={}
+end
+
+function GamepadState:press(button)
+  self.keys[button]=true
+end
+
+function GamepadState:release(button)
+  self.keys[button]=false
+end
+
+function GamepadState:isPressed(button)
+  if self.keys[button] ~= nil then
+    return self.keys[button]
+  end
+  return false
+end
+
+function GamepadState:isReleased(button)
+  if self.keys[button] ~= nil then
+    return not self.keys[button]
+  end
+  return true
+end
+


### PR DESCRIPTION
During testing we found a problem with event-based input handling: we got more events than we should, depending on the hardware even for keys not being pressed or released.

This commit defines a new class, GamepadState, which stores the current state of all keys based on the last events.

Based on this state events are ignored, if they are not valid for the current (assumed) state of the gamepad. That means:

* if a release event fires for a button not pressed, it is ignored.
* if a press event fires for a button not released, it is ignored.
* if a press event fires for a released button, the state gets updated and the event fires into the current screen.
* if a release event fires for a pressed button, the state gets updated and the event fires into the current screen.