### PR TITLE
feat: screen shake when player takes damage

### DIFF
--- a/Game/game.lua
+++ b/Game/game.lua
@@ -35,12 +35,14 @@ game.start = function()
   game.players = {}
   game.screens = Stack()
   game.inputManager = InputManager()
+  game.effects = Effects()
   game.switchScreen(RookScreen())
 end
 
 game.restart = function()
   game.players = {}
   game.screens = Stack()
+  game.effects = Effects()
   love.audio.stop()
   if game.inputManager == nil then game.inputManager = InputManager() end -- inputManager is only null if we use restart as quickstart function
   game.inputManager:restart()
@@ -77,4 +79,3 @@ game.endGame = function()
 end
 
 game.quickStart = game.restart
-

--- a/Game/init.lua
+++ b/Game/init.lua
@@ -10,6 +10,7 @@ push = require('lib/push') -- gives us resizable screens
 --CORE
 require('src/core/Stack')
 require('src/core/find')
+require('src/effects/Effects')
 
 --GLOBALS
 require('src/session')
@@ -26,4 +27,3 @@ require('src/collisions/Collisions')
 require('src/level/Level')
 require('src/player/Player')
 require('src/screens/Screens') 
-

--- a/Game/lib/push.lua
+++ b/Game/lib/push.lua
@@ -64,6 +64,9 @@ function push:setupScreen(WWIDTH, WHEIGHT, RWIDTH, RHEIGHT, settings)
     ["end"] = self.finish
   }
 
+  self._renderOffsetX = 0
+  self._renderOffsetY = 0
+
   return self
 end
 
@@ -209,6 +212,7 @@ function push:finish(shader)
     local shader = shader or _render.shader
     love.graphics.push()
     love.graphics.scale(self._SCALE.x, self._SCALE.y)
+    love.graphics.translate(self._renderOffsetX or 0, self._renderOffsetY or 0)
     self:applyShaders(_render.canvas, type(shader) == "table" and shader or { shader })
     love.graphics.pop()
 
@@ -228,6 +232,11 @@ end
 
 function push:setBorderColor(color, g, b)
   self._borderColor = g and {color, g, b} or color
+end
+
+function push:setRenderOffset(x, y)
+  self._renderOffsetX = x or 0
+  self._renderOffsetY = y or 0
 end
 
 function push:toGame(x, y)

--- a/Game/src/effects/Effects.lua
+++ b/Game/src/effects/Effects.lua
@@ -1,0 +1,33 @@
+require('src/effects/ScreenShakeEffect')
+
+Effects = Object:extend()
+
+function Effects:new()
+  self.screenShake = ScreenShakeEffect({
+    duration = 0.14,
+    amplitude = 11,
+    frequency = 14,
+  })
+
+  return self
+end
+
+function Effects:update(dt)
+  self.screenShake:update(dt)
+end
+
+function Effects:triggerScreenShake(config)
+  self.screenShake:start(config)
+end
+
+function Effects:getOffsetY()
+  if self.screenShake:isActive() then
+    local offsetY = self.screenShake:getOffsetY()
+    if offsetY >= 0 then
+      return math.floor(offsetY + 0.5)
+    end
+    return math.ceil(offsetY - 0.5)
+  end
+
+  return 0
+end

--- a/Game/src/effects/ScreenShakeEffect.lua
+++ b/Game/src/effects/ScreenShakeEffect.lua
@@ -1,0 +1,55 @@
+ScreenShakeEffect = Object:extend()
+
+function ScreenShakeEffect:new(config)
+  config = config or {}
+
+  self.duration = config.duration or 0.08
+  self.amplitude = config.amplitude or 4
+  self.frequency = config.frequency or 75
+
+  self.timeLeft = 0
+  self.offsetY = 0
+  self.active = false
+
+  return self
+end
+
+function ScreenShakeEffect:start(config)
+  config = config or {}
+
+  if config.duration ~= nil then self.duration = config.duration end
+  if config.amplitude ~= nil then self.amplitude = config.amplitude end
+  if config.frequency ~= nil then self.frequency = config.frequency end
+
+  self.timeLeft = self.duration
+  self.offsetY = 0
+  self.active = true
+end
+
+function ScreenShakeEffect:update(dt)
+  if not self.active then return end
+
+  self.timeLeft = self.timeLeft - dt
+
+  if self.timeLeft <= 0 then
+    self.timeLeft = 0
+    self.offsetY = 0
+    self.active = false
+    return
+  end
+
+  local elapsed = self.duration - self.timeLeft
+  local progress = elapsed / self.duration
+  local damping = 1 - progress
+  local wave = math.sin(elapsed * self.frequency * math.pi * 2)
+
+  self.offsetY = wave * self.amplitude * damping
+end
+
+function ScreenShakeEffect:isActive()
+  return self.active
+end
+
+function ScreenShakeEffect:getOffsetY()
+  return self.offsetY
+end

--- a/Game/src/player/states/ActionStates/DamageState.lua
+++ b/Game/src/player/states/ActionStates/DamageState.lua
@@ -28,6 +28,7 @@ function DamageState:enterState()
   player.startTimer = love.timer.getTime()
   player.anim = player.animations[Constants.DAMAGE_STATE][player.animationDirection]
   player:setDamage(1)
+  if game.effects ~= nil then game.effects:triggerScreenShake() end
   
   self.audio.damage[math.random(9)]:play()
   player.isMovementBlocked = true

--- a/Game/src/screens/level/Screen.lua
+++ b/Game/src/screens/level/Screen.lua
@@ -25,6 +25,10 @@ function LevelScreen:enter()
 end
 
 function LevelScreen:update(dt)
+  if game.effects ~= nil then
+    game.effects:update(dt)
+  end
+
   if self.isPaused or self.isEnded then return end
 
   local allPlayers = self.session.instance.players
@@ -40,6 +44,11 @@ function LevelScreen:update(dt)
 end
 
 function LevelScreen:draw()
+  if game.effects ~= nil then
+    push:setRenderOffset(0, game.effects:getOffsetY())
+  else
+    push:setRenderOffset(0, 0)
+  end
 
   self.session.instance.level:draw()    
   for i = 1, #self.session.instance.players do
@@ -132,6 +141,7 @@ function LevelScreen:resume()
 end
 
 function LevelScreen:exit()
+  push:setRenderOffset(0, 0)
   for i, player in ipairs(self.session.instance.playerinputs) do
     game.inputManager.HandlerStack:pop()
   end


### PR DESCRIPTION
This adds a small visual feedback when a player takes damage by making the screen shake briefly.

It is done by introducing a ScreenShakeEffect type on the game object that gets updated and calculates the math for a vertical offset. This offset then gets applied to the screen in the push.lua file by translating the whole screen.